### PR TITLE
change some return code from NGX_OK to NGX_DECLINED

### DIFF
--- a/ngx_http_dynamic_limit_req_module.c
+++ b/ngx_http_dynamic_limit_req_module.c
@@ -169,7 +169,7 @@ static ngx_int_t ngx_http_limit_req_handler(ngx_http_request_t *r) {
 					/* Redis if the connection is wrong,
 					 *  it does not intercept,
 					 *   and returns normally */
-					return NGX_OK;
+					return NGX_DECLINED;
 				} else {
 					ngx_log_error(lrcf->limit_log_level, r->connection->log, 0,
 							"redis connection error: can't allocate redis context\n");
@@ -246,7 +246,7 @@ static ngx_int_t ngx_http_limit_req_handler(ngx_http_request_t *r) {
 		reply = redisCommand(c, "GET %s", Host);
 		if (reply->str == NULL) {
 			freeReplyObject(reply);
-			return NGX_OK;
+			return NGX_DECLINED;
 		}
 	}
 	/* return http_status redis*/


### PR DESCRIPTION
Hi limithit, I'm using your great Nginx's module for my web server, but, I've just found out a problem. The problem is: when requests don't exceed limit, or the source IP's in whitelist, module will return NGX_OK instead of NGX_DECLINED, which means, these requests will bypass all modules which are registered in PREACCESS phase (such as modsecurity). So I made a small fix in code and tested OK on nginx 1.16.0, 1.14.0, other versions should work well too.
Please consider my pull request. Thank you!